### PR TITLE
Add :post_bundle_install feature request

### DIFF
--- a/lib/cartage/plugins/bundler.rb
+++ b/lib/cartage/plugins/bundler.rb
@@ -101,6 +101,8 @@ class Cartage::Bundler < Cartage::Plugin
         cartage.run bundle_command
       end
     end
+
+    cartage.plugins.request(:post_bundle_install)
   end
 
   def bundle_command


### PR DESCRIPTION
- Adds :post_bundle_install feature request to this plugin. This is to allow
  other plugins hook into the completion of a bundle install.